### PR TITLE
Changed precision to use multiplicative inverse

### DIFF
--- a/src/jRate.js
+++ b/src/jRate.js
@@ -285,6 +285,12 @@ Demo: http://www.toolitup.com/JRate.html
             }
         }
 
+		function workOutPrecision(num) {
+			var multiplactiveInverse = 1/settings.precision;
+
+			return Math.round(num*multiplactiveInverse)/multiplactiveInverse;
+		}
+
         function onEnterOrClickEvent(e, ith, label, update) {
             if (settings.readOnly) return;
 
@@ -300,7 +306,7 @@ Demo: http://www.toolitup.com/JRate.html
             var count = (settings.max - settings.min) / settings.count;
             partial = (settings.reverse) ? partial : 1 - partial;
             var rating = ((settings.reverse ? (settings.max - settings.min - ith + 1) : ith) - partial) * count;
-            rating = settings.min + Number(rating.toFixed(settings.precision));
+            rating = settings.min + Number(workOutPrecision(rating));
 	
             if (rating <= settings.max && rating >= settings.min) {
                 showRating(rating);
@@ -330,7 +336,7 @@ Demo: http://www.toolitup.com/JRate.html
 			var count = (settings.max - settings.min) / settings.count;
 			partial = (settings.reverse) ? partial : 1 - partial;
 			var rating = ((settings.reverse ? (settings.max - settings.min - ith + 1) : ith) - partial) * count;
-			rating = settings.min + Number(rating.toFixed(settings.precision));
+			rating = settings.min + Number(workOutPrecision(rating));
 	
 			if (rating <= settings.max && rating >= settings.min) {
                 showRating(rating);


### PR DESCRIPTION
Due to how you couldn't get the plugin to allow a precision of half-stars when selecting your rating, this commit changes how the precision is worked out.

For example, putting a precision of 0.5 with a min of 1 and a max of 2 will give you the options to rate of 1, 1.5 and 2.
Putting a precision of 0.25 with a min of 1 and a max of 2 will give you the options of 1, 1.25, 1.5, 1.75 and 2.

Before setting a precision of 1 with a min of 1 and a max of 2 would give you the options to rate of 1, 1.1, 1.2, 1.3 and so on.